### PR TITLE
Add Requirements to docs

### DIFF
--- a/README.in.rst
+++ b/README.in.rst
@@ -18,9 +18,14 @@
 
 Requirements
 ============
- .. rbenv: https://github.com/rbenv/rbenv
- .. rbenv.el: https://github.com/senny/rbenv.el
-      
+ - `rbenv`_
+ - `rbenv.el`_
+ - `bunlder`_
+   
+ .. _rbenv: https://github.com/rbenv/rbenv
+ .. _rbenv.el: https://github.com/senny/rbenv.el
+ .. _bundler: https://bundler.io/
+ 
 Install
 =======
 As described in `Getting started`_, ensure melpa's whereabouts in ``init.el`` or ``.emacs``::

--- a/README.in.rst
+++ b/README.in.rst
@@ -16,6 +16,11 @@
 .. |---| unicode:: U+2014  .. em dash, trimming surrounding whitespace
    :trim:
 
+Requirements
+============
+ .. rbenv: https://github.com/rbenv/rbenv
+ .. rbenv.el: https://github.com/senny/rbenv.el
+      
 Install
 =======
 As described in `Getting started`_, ensure melpa's whereabouts in ``init.el`` or ``.emacs``::

--- a/README.in.rst
+++ b/README.in.rst
@@ -20,12 +20,12 @@ Requirements
 ============
  - `rbenv`_
  - `rbenv.el`_
- - `bunlder`_
-   
+ - `bundler`_
+
  .. _rbenv: https://github.com/rbenv/rbenv
  .. _rbenv.el: https://github.com/senny/rbenv.el
  .. _bundler: https://bundler.io/
- 
+
 Install
 =======
 As described in `Getting started`_, ensure melpa's whereabouts in ``init.el`` or ``.emacs``::

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
 |build-status|
 
-A Gnus backend for Discourse.
 
 .. |build-status|
    image:: https://github.com/dickmao/nndiscourse/workflows/CI/badge.svg
@@ -15,6 +14,16 @@ A Gnus backend for Discourse.
 .. |--| unicode:: U+2013   .. en dash
 .. |---| unicode:: U+2014  .. em dash, trimming surrounding whitespace
    :trim:
+
+Requirements
+============
+ - `rbenv`_
+ - `rbenv.el`_
+ - `bundler`_
+
+ .. _rbenv: https://github.com/rbenv/rbenv
+ .. _rbenv.el: https://github.com/senny/rbenv.el
+ .. _bundler: https://bundler.io/
 
 Install
 =======


### PR DESCRIPTION
Added links to `rbenv`,`rbenv.el`, and `bundler` to the docs as they are all required to use the plugin. 