### PR TITLE
Replace deprecated dash-functional dependency

### DIFF
--- a/nndiscourse.el
+++ b/nndiscourse.el
@@ -6,7 +6,7 @@
 ;; Version: 0.1.0
 ;; Keywords: news
 ;; URL: https://github.com/dickmao/nndiscourse
-;; Package-Requires: ((emacs "25.1") (dash "2.16") (dash-functional "1.2.0") (anaphora "1.0.4") (rbenv "0.0.3") (json-rpc "20200417"))
+;; Package-Requires: ((emacs "25.1") (dash "2.18") (anaphora "1.0.4") (rbenv "0.0.3") (json-rpc "20200417"))
 
 ;; This file is NOT part of GNU Emacs.
 
@@ -48,7 +48,6 @@
 (require 'json)
 (require 'subr-x)
 (require 'dash)
-(require 'dash-functional)
 (require 'anaphora)
 (require 'json-rpc)
 (require 'rbenv)


### PR DESCRIPTION
Dash 2.18.0 now subsumes `dash-functional`.

See https://github.com/magnars/dash.el/blob/master/NEWS.md#from-217-to-218